### PR TITLE
Minor update in the starter kit H2O Wave app UI

### DIFF
--- a/wave-app/src/ui_utils.py
+++ b/wave-app/src/ui_utils.py
@@ -16,7 +16,7 @@ async def init_ui(q: Q):
     # Footer card to display a caption of embeded html for the footer.
     q.page['footer'] = ui.footer_card(
         box='footer',
-            caption='Made with 💛️ using Wave. (c) 2021 H2O.ai. All rights reserved.'
+            caption='Made with 💛️ using H2O Wave.'
     )
 
 


### PR DESCRIPTION
Updated the footer card in the starter kit wave app to remove the copyright statement as the source/app are open source.